### PR TITLE
Add: redirect to hello page with token after kakaologin

### DIFF
--- a/src/pages/Hello/Hello.js
+++ b/src/pages/Hello/Hello.js
@@ -1,4 +1,4 @@
-import { Link, Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Confetti from 'react-confetti';
 import { useEffect } from 'react';

--- a/src/pages/Hello/Hello.js
+++ b/src/pages/Hello/Hello.js
@@ -1,8 +1,26 @@
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Confetti from 'react-confetti';
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 function Hello() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  let token = new URL(window.location.href).searchParams.get('token');
+  let auth;
+  useEffect(() => {
+    if (token) {
+      navigate('./', {
+        state: { token: token },
+      });
+    }
+  }, [token]);
+
+  if (location?.state?.token) {
+    auth = location.state.token;
+    console.log('auth ', auth);
+  } 
   return (
     <Main>
       <Section>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 사항

- 카카오 로그인 성공 후 로그인 토큰 정보를 queryparam 에 담아 hello 페이지로 이동. 
- 토큰을 location state 에 저장 후 hello 페이지로 다시 navigate 하여 url 에 token 정보가 표시되지 않게 함

<br />



