### PR TITLE
Feature/kakaologin] EDIT: 카카오 로그인 시 헤더 변경, 카카오 로그인 유저 로그아웃 핸들러

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-BASE_URL=mysql://root:qudtls1202@localhost:3306/codlearn
-REACT_APP_BASE_URL=http://localhost:10010

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
-
+.env
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /build
 
 # misc
-.env
 .DS_Store
 .env.local
 .env.development.local

--- a/src/components/Header/HeaderBottom.js
+++ b/src/components/Header/HeaderBottom.js
@@ -13,11 +13,12 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import Login from '../Login/Login';
 import { LoginContext } from '../../App';
+import BASE_URL from '../../config';
+import * as oAuth from '../Login/OAuth';
 library.add(faMagnifyingGlass, faCartShopping, faBell, faUser);
 
 function HeaderBottom() {
-  const token = localStorage.getItem('token');
-
+  const [token, setToken] = useState();
   const [isLogin, setIsLogin] = useContext(LoginContext);
 
   const [modal, setModal] = useState(false);
@@ -28,7 +29,6 @@ function HeaderBottom() {
   const searchParams = new URLSearchParams(query);
   const navigate = useNavigate();
   const location = useLocation();
-  const loginToken = localStorage.getItem('token');
 
   const openModal = () => {
     setModal(true);
@@ -43,6 +43,7 @@ function HeaderBottom() {
   };
 
   useEffect(() => {
+    setToken(localStorage.getItem('token'));
     (() => {
       window.addEventListener('scroll', () => setScrollY(window.pageYOffset));
       if (scrollY > 104) {
@@ -84,14 +85,32 @@ function HeaderBottom() {
   }, [text]);
 
   useEffect(() => {
-    if (localStorage.getItem('token')) {
+    if (token) {
       setIsLogin(true);
     } else {
       setIsLogin(false);
     }
-  }, [loginToken]);
+  }, [token]);
 
-  const logout = () => {
+  const kakaoLogout = async token => {
+    try {
+      await fetch(`${BASE_URL}/user/kakao/logout`, {
+        method: 'POST',
+        headers: {
+          Authorization: token,
+        },
+      })
+        .then(res => res.json())
+        .then(data => {
+          console.log('data ', data);
+        });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const logout = async () => {
+    await kakaoLogout(token);
     localStorage.removeItem('token');
     setIsLogin(false);
     goToHome();

--- a/src/components/Login/KakaoLogin.js
+++ b/src/components/Login/KakaoLogin.js
@@ -1,12 +1,11 @@
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { KAKAO_AUTH_URL } from './OAuth';
-import { REDIRECT_URI } from './OAuth';
+import * as oAuth from '../Login/OAuth';
 
 function KakaoLogin() {
   const CLIENT_ID = process.env.REACT_APP_REST_API_KEY;
 
-  const requestURL = `${KAKAO_AUTH_URL}/?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+  const requestURL = `${oAuth.KAKAO_AUTH_URL}/?client_id=${CLIENT_ID}&redirect_uri=${oAuth.REDIRECT_URI}&response_type=code`;
 
   const onClick = () => {
     window.open(requestURL);

--- a/src/components/Login/OAuth.js
+++ b/src/components/Login/OAuth.js
@@ -1,3 +1,8 @@
-const CLIENT_ID = process.env.REST_API_KEY;
+
 export const REDIRECT_URI = 'http://localhost:10010/user/kakao/login';
+export const FRONT_REDIRECT_URL = 'http://localhost:3000';
 export const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
+export const KAKAO_OAUTH_LOGOUT_API_URL =
+  'https://kauth.kakao.com/oauth/logout';
+export const KAKAO_CONTENT_TYPE =
+  'application/x-www-form-urlencoded;charset=utf-8';

--- a/src/pages/Home/SearchBar/SearchBar.js
+++ b/src/pages/Home/SearchBar/SearchBar.js
@@ -43,7 +43,6 @@ function SearchBar() {
 
   let searchQuery = new URLSearchParams(useLocation().search);
   let courses = searchQuery.get('courses');
-  console.log(courses);
   const goToCoure = () => {
     //setQuery(`/${courses}?s=${inputText}`);
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

- 카카오 로그인 시 로그인 상태로 헤더가 바로 변경되지 않고, 다음 페이지 렌더링에서 변경되는 버그 수정
- 카카오 로그인 유저의 로그아웃 핸들 함수 추가

<br />

## :: 구현 사항 설명

1. 카카오 로그인 시 로그인 상태로 헤더 변경
-  useEffect 상태 조건/페이지 렌더링 조건 변경하여 카카오 로그인 성공 후 첫 렌더링에서 헤더가 이를 반영할 수 있게 함.

2. 카카오 로그인 유저의 로그아웃 함수 추가
- 카카오 토큰을 만료 시키는 API 를 호출 함. 


